### PR TITLE
Add settings links

### DIFF
--- a/pretalx_halfnarp/apps.py
+++ b/pretalx_halfnarp/apps.py
@@ -22,6 +22,12 @@ class PluginApp(AppConfig):
         visible = True
         version = __version__
         category = "FEATURE"
+        settings_links = [
+            (gettext_lazy("Settings"), "plugins:pretalx_halfnarp:settings", {}),
+        ]
+        navigation_links = [
+            (gettext_lazy("Dashboard"), "plugins:pretalx_halfnarp:organiser", {}),
+        ]
 
     def ready(self):
         from . import signals  # NOQA


### PR DESCRIPTION
Plugins can now define links to their settings page and their other pages.